### PR TITLE
Update doctr deploy API usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
   - set -e
   - mkdocs build --clean --verbose
-  - doctr deploy --built-docs=_site --gh-pages-docs .
+  - doctr deploy --built-docs=_site .


### PR DESCRIPTION
Deploy directory is now a required argument and `--gh-pages-docs` flag is deprecated