### PR TITLE
Update doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
   - set -e
   - mkdocs build --clean --verbose
-  - doctr deploy --built-docs=_site --gh-pages-docs .
+  - doctr deploy --built-docs=_site .


### PR DESCRIPTION
The `--gh-pages-docs` flag is deprecated and the deploy directory is now a required argument.